### PR TITLE
Fix bug with adding node from folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "vscode-file-explorer-enhancements" extension will be
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+### 1.0.2
 
-- Initial release
+* Fixed bug where adding a node when a folder was selected resulted in the base path being the folder's parent.
+
+### 1.0.1
+
+* Fixed list node so it works on Windows.
+
+### 1.0.0
+
+Initial release of the plugin.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+### 1.0.2
+
+* Fixed bug where adding a node when a folder was selected resulted in the base path being the folder's parent.
+
 ### 1.0.1
 
 * Fixed list node so it works on Windows.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"repository": {
 		"url": "https://github.com/sendhil/vscode-file-explorer-menu"
 	},
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"engines": {
 		"vscode": "^1.49.0"
 	},

--- a/src/addChildNode.ts
+++ b/src/addChildNode.ts
@@ -16,7 +16,18 @@ export async function addChildNode() {
 	if (rootFolder) {
 		startingFilePath = `${rootFolder.uri.fsPath}/`;
 	} else {
-		startingFilePath = `${path.dirname(await getCurrentlySelectedFilePath())}/`;
+		// If the currently selected file is a folder, then don't use `path.dirname` as it'll end up returning the parent folder.
+
+		let currentlySelectedFile = await getCurrentlySelectedFilePath();
+		const fileStats = await vscode.workspace.fs.stat(vscode.Uri.file(currentlySelectedFile));
+		if (fileStats.type === vscode.FileType.Directory) {
+			startingFilePath = currentlySelectedFile;
+			if (startingFilePath[startingFilePath.length - 1] !== '/') {
+				startingFilePath += "/";
+			}
+		} else {
+			startingFilePath = `${path.dirname(currentlySelectedFile)}/`;
+		}
 	}
 
 	const newFilePath = (await vscode.window.showInputBox({


### PR DESCRIPTION
Fixed a bug where if you tried to add a node when a folder was selected the default path ended up being the parent folder.